### PR TITLE
Use LinAlg.A_rdiv_B! to reduce allocations a bit.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 test/libnnls.dylib
+test/libnnls.so

--- a/src/NNLS.jl
+++ b/src/NNLS.jl
@@ -759,7 +759,8 @@ function solve!(work::QPWorkspace{T}, eps_infeasible = 1e-4) where T
     # Compute M
     cholQ = cholfact!(Q, :U)
     L = cholQ[:U]
-    M .= G / L
+    M[:] = G
+    LinAlg.A_rdiv_B!(M, L)
 
     # Compute d
     e[:] = c


### PR DESCRIPTION
For some reason `LinAlg.A_rdiv_B!` isn't exported, which is why I didn't use it earlier.